### PR TITLE
Changed TensorFlow version requirement to <2.12.0 on requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy<=1.23.4
 tensorflowjs
-tensorflow
+tensorflow<2.12.0
 pandas


### PR DESCRIPTION
Changed TensorFlow version requirement to <2.12.0 on requirements.txt for Ticket 1631 on aisquared DevOps